### PR TITLE
fix: Update repository URLs and streamline CI/CD config

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -182,13 +182,10 @@ jobs:
         tag_prefix: "v"
         major_pattern: "(BREAKING CHANGE|\\!:)"
         minor_pattern: "(feat|feature):"
-        patch_pattern: "(fix|bugfix|hotfix):"
         version_format: "${major}.${minor}.${patch}"
         change_path: "src/"
-        namespace: ""
         bump_each_commit: false
         search_commit_body: true
-        user_format_type: "csv"
         
     - name: Create changelog
       id: changelog

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Add this repository to your Maven settings.xml:
 <repositories>
   <repository>
     <id>github</id>
-    <url>https://maven.pkg.github.com/voicify/keycloak-api-key-extension</url>
+    <url>https://maven.pkg.github.com/getvoicify/api-key-extension</url>
   </repository>
 </repositories>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -211,12 +211,12 @@
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/voicify/keycloak-api-key-extension</url>
+            <url>https://maven.pkg.github.com/getvoicify/api-key-extension</url>
         </repository>
         <snapshotRepository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/voicify/keycloak-api-key-extension</url>
+            <url>https://maven.pkg.github.com/getvoicify/api-key-extension</url>
         </snapshotRepository>
     </distributionManagement>
 </project>


### PR DESCRIPTION
- Updated GitHub Packages repository URLs in `pom.xml` and `README.md`.
- Removed unused patterns and unnecessary fields from `ci-cd.yml` for simplification.