### PR TITLE
feat: add MIT license, fix repository URLs, and add code coverage sup…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,8 +67,8 @@ jobs:
     - name: Compile project
       run: ./mvnw clean compile
       
-    - name: Run tests
-      run: ./mvnw test
+    - name: Run tests with coverage
+      run: ./mvnw test jacoco:report
       
     - name: Generate test report
       uses: dorny/test-reporter@v1
@@ -92,6 +92,15 @@ jobs:
       with:
         name: coverage-reports
         path: target/site/jacoco/
+        
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      if: always()
+      with:
+        file: target/site/jacoco/jacoco.xml
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false
 
   package:
     name: Package Application

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -137,8 +137,8 @@ jobs:
     - name: Compile project
       run: ./mvnw clean compile
       
-    - name: Run tests
-      run: ./mvnw test
+    - name: Run tests with coverage
+      run: ./mvnw test jacoco:report
       
     - name: Generate test report
       uses: dorny/test-reporter@v1
@@ -156,6 +156,23 @@ jobs:
         name: pr-test-results-${{ github.event.pull_request.number }}
         path: target/surefire-reports/
         retention-days: 7
+        
+    - name: Upload coverage reports
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: pr-coverage-reports-${{ github.event.pull_request.number }}
+        path: target/site/jacoco/
+        retention-days: 7
+        
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      if: always()
+      with:
+        file: target/site/jacoco/jacoco.xml
+        flags: unittests,pr
+        name: codecov-pr
+        fail_ci_if_error: false
         
     - name: Update PR Status - Build & Test Passed
       if: success()

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Voicify
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Keycloak API Key Extension
 
-[![CI/CD Pipeline](https://github.com/voicify/keycloak-api-key-extension/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/voicify/keycloak-api-key-extension/actions/workflows/ci-cd.yml)
+[![CI/CD Pipeline](https://github.com/getvoicify/api-key-extension/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/getvoicify/api-key-extension/actions/workflows/ci-cd.yml)
+[![codecov](https://codecov.io/gh/getvoicify/api-key-extension/branch/main/graph/badge.svg)](https://codecov.io/gh/getvoicify/api-key-extension)
 
 A Keycloak extension that provides API key functionality for the Voicify platform. This extension adds REST endpoints to create and validate API keys stored as user attributes in Keycloak.
 
@@ -101,7 +102,7 @@ Add this repository to your Maven settings.xml:
 </repositories>
 ```
 
-Then include the dependency (check [releases](https://github.com/voicify/keycloak-api-key-extension/releases) for latest version):
+Then include the dependency (check [releases](https://github.com/getvoicify/api-key-extension/releases) for latest version):
 
 ```xml
 <dependency>
@@ -134,4 +135,4 @@ The project uses two separate GitHub Actions workflows:
 
 ## License
 
-[Add your license information here]
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
- Add MIT License file with proper Voicify copyright
- Update CI/CD pipeline badge links to correct repository URL
- Fix GitHub Packages and releases links in README
- Add JaCoCo code coverage reporting to both workflows
- Integrate Codecov for coverage visualization
- Add coverage badge to README
- Update license section in README

🤖 Generated with [Claude Code](https://claude.ai/code)