### PR TITLE
feat: implement API key retrieval functionality using TDD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a Keycloak extension that provides API key functionality for the Voicify platform. The extension adds REST endpoints to create, rotate, and validate API keys stored as user attributes in Keycloak.
+This is a Keycloak extension that provides API key functionality for the Voicify platform. The extension adds REST endpoints to create, retrieve, rotate, and validate API keys stored as user attributes in Keycloak.
 
 ## Build System
 
@@ -23,17 +23,19 @@ The final JAR is built as `com.getvoicify-api-key-extension.jar` in the `target/
 
 1. **ApiKeyResourceProviderFactory** (`src/main/java/com/getvoicify/providers/ApiKeyResourceProviderFactory.java:10`) - Factory class that registers the "api-key" provider with Keycloak
 2. **ApiKeyResourceProvider** (`src/main/java/com/getvoicify/providers/ApiKeyResourceProvider.java:14`) - Provider that creates the API key resource
-3. **ApiKeyResource** (`src/main/java/com/getvoicify/resources/ApiKeyResource.java:21`) - Main REST resource with three endpoints:
+3. **ApiKeyResource** (`src/main/java/com/getvoicify/resources/ApiKeyResource.java:21`) - Main REST resource with four endpoints:
    - `GET /check?apiKey=...` - Validates an API key
+   - `GET /` - Retrieves the authenticated user's API key
    - `POST /` - Creates a new API key for authenticated users
    - `PUT /rotate` - Rotates an existing API key for authenticated users
 
 ### Authentication Flow
 
 The extension requires:
-- Bearer token authentication for API key creation and rotation
+- Bearer token authentication for API key creation, retrieval, and rotation
 - User must have the "create-pat" role in the "iam" client
 - API keys are stored as "api-key" user attributes using JPA entities
+- Retrieval returns API key in JSON format or 404 if none exists
 - Rotation replaces existing API keys with newly generated ones
 
 ### Key Dependencies
@@ -55,9 +57,13 @@ Key test scenarios:
 - API key validation without key (401 expected)
 - API key creation without authentication (401 expected)
 - Successful API key creation with proper authentication (200 expected)
+- API key retrieval without authentication (403 expected)
+- API key retrieval when no key exists (404 expected)
+- Successful API key retrieval with proper authentication (200 expected)
 - API key rotation without authentication (403 expected)
 - Successful API key rotation with proper authentication (200 expected)
 - Multiple rotations to ensure repeatability
+- API key differences after rotation
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ A Keycloak extension that provides API key functionality for the Voicify platfor
 ## Features
 
 - **API Key Creation**: Create API keys for authenticated users with proper role validation
+- **API Key Retrieval**: Retrieve existing API keys for authenticated users
 - **API Key Validation**: Validate API keys via REST endpoint
 - **API Key Rotation**: Rotate existing API keys for enhanced security
-- **Role-Based Access**: Requires "create-pat" role in "iam" client for API key creation
+- **Role-Based Access**: Requires "create-pat" role in "iam" client for API key operations
 - **Jakarta EE Compatible**: Built for Keycloak 26.x with full Jakarta EE support
 
 ## Build and Test
@@ -45,6 +46,7 @@ A Keycloak extension that provides API key functionality for the Voicify platfor
 The extension provides the following REST endpoints under `/realms/{realm-name}/api-key/`:
 
 - `GET /check?apiKey=...` - Validates an API key
+- `GET /` - Retrieves the authenticated user's API key
 - `POST /` - Creates a new API key for authenticated users
 - `PUT /rotate` - Rotates an existing API key for authenticated users
 
@@ -54,6 +56,12 @@ The extension provides the following REST endpoints under `/realms/{realm-name}/
 - Requires Bearer token authentication
 - User must have "create-pat" role in "iam" client
 - API keys are stored as "api-key" user attributes
+
+### API Key Retrieval (`GET /`)
+- Requires Bearer token authentication
+- User must have "create-pat" role in "iam" client
+- Returns API key in JSON format: `{"apiKey": "..."}`
+- Returns 404 if user has no existing API key
 
 ### API Key Rotation (`PUT /rotate`)
 - Requires Bearer token authentication


### PR DESCRIPTION
- Add GET / endpoint for retrieving authenticated user's API key
- Implement getApiKeyAttribute helper method with proper EntityManager state management
- Add comprehensive test suite for retrieval scenarios:
  - Authentication required (403 without Bearer token)
  - Returns 404 when user has no API key
  - Returns 200 with JSON response when user has API key
  - Verifies API key changes after rotation
  - Includes robust test handling for integration test interference
- Return API key in JSON format: {"apiKey": "..."}
- Update documentation in README.md and CLAUDE.md:
  - Add retrieval feature to features list
  - Document new GET / endpoint with authentication requirements
  - Update test scenarios to include retrieval functionality
- Follow Test-Driven Development methodology:
  - Red: Write failing tests first for all scenarios
  - Green: Implement minimal code to pass tests
  - Refactor: Improve implementation and make tests robust

The API key retrieval feature enhances the extension's usability by allowing users to programmatically retrieve their existing API keys for integration into applications and services.

🤖 Generated with [Claude Code](https://claude.ai/code)